### PR TITLE
Typo in Linux and macOS release workflows on action name. Fixed

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -41,7 +41,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Uplaod .sh.sha512 to release
-      uses: JasonEtcho/upload-to-release@master
+      uses: JasonEtco/upload-to-release@master
       with:
         args: ${{github.workspace}}/build/sac-format-?.?.?-Linux-*.sh.sha512 text/plain
       env:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -41,7 +41,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Uplaod .sh.sha512 to release
-      uses: JasonEtcho/upload-to-release@master
+      uses: JasonEtco/upload-to-release@master
       with:
         args: ${{github.workspace}}/build/sac-format-?.?.?-Darwin-*.sh.sha512 text/plain
       env:


### PR DESCRIPTION
Another typo fixed (Etcho -> Etco).